### PR TITLE
Remove binding of haskell-mode-jump-to-def-or-tag

### DIFF
--- a/tutorial.md
+++ b/tutorial.md
@@ -105,8 +105,6 @@ Then open the personal configuration file and add the following lines:
 (setenv "PATH" (concat "~/.cabal/bin:" (getenv "PATH")))
 (add-to-list 'exec-path "~/.cabal/bin")
 (custom-set-variables '(haskell-tags-on-save t))
-(add-hook 'haskell-mode-hook
-          (lambda () (define-key haskell-mode-map (kbd "M-.") 'haskell-mode-jump-to-def-or-tag)))
 ```
 The first two lines are needed to tell Emacs that it should look for the `hasktags` program in your Cabal binaries directory, which is not a location it already knows about. The next line is the one enabling `hasktags` itself. Finally, we bind the `M-.` key combination to jump to the definition of an element when you are over it.
 


### PR DESCRIPTION
This binding is configured by default these days. And the mode hook code I removed would have had the effect of binding the key every time a haskell file was opened: it would have been sufficient to just put the `(define-key ...)` form at the top level, or in an `(eval-after-load 'haskell-mode ...)` wrapper.

Thanks for compiling this useful article. Will send further fixes if I notice anything. :-)
