### PR TITLE
Correctly escaped the C-` backtick in markdown.

### DIFF
--- a/tutorial.md
+++ b/tutorial.md
@@ -157,7 +157,7 @@ You will get an interpreter, except in the case you file has some errors that th
 ```
 Add {-# LANGUAGE BangPatterns #-} to the top of the file? (y or n)
 ```
-If you have errors that cannot be fixed automatically, the key combination `C-`` will navigate around them.
+If you have errors that cannot be fixed automatically, the key combination ``C-` `` will navigate around them.
 
 Note that the interpreter is a normal Haskell one, so you can run any command you want in the `λ>` prompt. `haskell-mode` contains many small features which make it more appealing to look and traverse Haskell values. Most of them do not need any special setup, except for my favourite: presenting a variable. To enable it, install the `present` package:
 ```
@@ -417,7 +417,7 @@ Key binding                       | Description
 `M-.`                             | jump to definition
 `M-x haskell-mode-stylish-buffer` | format file
 `C-c C-l`                         | load file in interpreter
-`C-``                             | navigate errors in the file (`haskell-mode`, interactive)
+``C-` ``                          | navigate errors in the file (`haskell-mode`, interactive)
 `C-c C-n C-t`                     | show type of expression (`haskell-mode`, interactive)
 `C-c C-n C-t`                     | show info of expression (interactive)
 `C-c C-n C-c`                     | run `cabal build` (interactive)


### PR DESCRIPTION
Needs to be surrounded by double backticks, with a space before the final two.
