### PR TITLE
add happy dep to list of cabal installs

### DIFF
--- a/tutorial.md
+++ b/tutorial.md
@@ -477,6 +477,6 @@ wait                              | show completions (`company-ghc`)
 This is the Haskell part of the modes using Cabal:
 ```
 cabal update
-cabal install hasktags stylish-haskell present ghc-mod hlint hoogle structured-haskell-mode
+cabal install happy hasktags stylish-haskell present ghc-mod hlint hoogle structured-haskell-mode
 ```
 The Emacs packages to be installed using `M-x package-install` are `haskell-mode`, `ghc`, `company-ghc` and `shm`.


### PR DESCRIPTION
`haskell-src-exts` is required by `ghc-mod` and a number of the other packages.  `haskell-src-exts` requires that `happy` be installed but for some reason it is not listed as a dep.  With this change this `cabal install` command works on a fresh install.
